### PR TITLE
Fix error on reorder functionality

### DIFF
--- a/Model/Total/Quote/Cashondelivery.php
+++ b/Model/Total/Quote/Cashondelivery.php
@@ -63,7 +63,11 @@ class Cashondelivery extends AbstractTotal
             $region = $quote->getShippingAddress()->getRegion();
         }
 
-        $baseAmount = $this->cashOnDeliveryInterface->getBaseAmount($total->getAllBaseTotalAmounts(), $country, $region);
+        $baseAmount = 0;
+        $totalAmounts = $total->getAllBaseTotalAmounts();
+        if ($totalAmounts) {
+            $baseAmount = $this->cashOnDeliveryInterface->getBaseAmount($totalAmounts, $country, $region);
+        }
         $amount = $this->priceCurrencyInterface->convert($baseAmount);
 
         if ($this->_canApplyTotal($quote)) {

--- a/Model/Total/Quote/CashondeliveryTax.php
+++ b/Model/Total/Quote/CashondeliveryTax.php
@@ -61,7 +61,11 @@ class CashondeliveryTax extends AbstractTotal
             $region = $quote->getShippingAddress()->getRegion();
         }
 
-        $baseAmount = $this->cashOnDeliveryInterface->getBaseAmount($total->getAllBaseTotalAmounts(), $country, $region);
+        $baseAmount = 0;
+        $totalAmounts = $total->getAllBaseTotalAmounts();
+        if ($totalAmounts) {
+            $baseAmount = $this->cashOnDeliveryInterface->getBaseAmount($totalAmounts, $country, $region);
+        }
 
         $baseTaxAmount = $this->cashOnDeliveryInterface->getBaseTaxAmount($baseAmount);
         $taxAmount = $this->priceCurrencyInterface->convert($baseTaxAmount);


### PR DESCRIPTION
When using the reorder functionality from the customer account section, the _getAllBaseTotalAmounts_ function on _Magento\Quote\Model\Quote\Address\Total_ returns null, causing the following error if the initial order had Cash on Delivery selected as payment method.

`
Fatal error: Uncaught TypeError: Argument 1 passed to MSP\CashOnDelivery\Model\Cashondelivery::getBaseAmount() must be of the type array, null given, called in vendor/msp/cashondelivery/Model/Total/Quote/Cashondelivery.php on line 66
`

The proposed solution calls the _getBaseAmount_ only if the result of that function is not null, if so it assumes the total is 0.