### PR TITLE
Fixes the compatibility issue with Magento 2.3 and improves the COD fee tax calculation

### DIFF
--- a/Api/CashondeliveryInterface.php
+++ b/Api/CashondeliveryInterface.php
@@ -48,4 +48,10 @@ interface CashondeliveryInterface
      * @return \MSP\CashOnDelivery\Api\CashondeliveryCartInterface
      */
     public function getCartInformation();
+
+    /**
+     * Returns true if the COD fee as saved in the DB already includes taxes, false otherwise
+     * @return bool
+     */
+    public function cashondeliveryFeeIncludesTax();
 }

--- a/Block/Sales/Cashondelivery.php
+++ b/Block/Sales/Cashondelivery.php
@@ -39,13 +39,17 @@ class Cashondelivery extends Template
         $parent = $this->getParentBlock();
         $source = $parent->getSource();
 
+        //@todo: Usually, if the fee is inputted as "VAT included" it means that it should also be displayed as "VAT
+        //  included". Likewise, if it is inputted as "VAT excluded", that's how it should be displayed.
+        //  However it would be even better to actually check how the total should be displayed instead of making
+        //  assumptions
         $payment = $this->getPayment($source);
         if ($payment && ($payment->getMethod() == Payment::CODE)) {
             $fee = new DataObject(
                 [
                     'code' => 'msp_cashondelivery',
                     'strong' => false,
-                    'value' => $source->getBaseMspCodAmount() - $source->getBaseMspCodTaxAmount(),
+                    'value' => $source->getBaseMspCodAmount(),  //See comment block above
                     'label' => __('Cash on delivery'),
                 ]
             );

--- a/Model/Config/Source/Fee/Tax.php
+++ b/Model/Config/Source/Fee/Tax.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MSP\CashOnDelivery\Model\Config\Source\Fee;
+
+final class Tax implements \Magento\Framework\Option\ArrayInterface
+{
+    const USE_SHIPPING_PRICE = 0;
+    const INCLUDING_TAX = 1;
+    const EXCLUDING_TAX = 2;
+
+    public function toOptionArray()
+    {
+        return [
+            ['value' => self::USE_SHIPPING_PRICE, 'label' => __('Use shipping price setting')],
+            ['value' => self::INCLUDING_TAX, 'label' => __('Including Tax')],
+            ['value' => self::EXCLUDING_TAX, 'label' => __('Excluding Tax')],
+        ];
+    }
+}

--- a/Model/Total/Quote/CashondeliveryTax.php
+++ b/Model/Total/Quote/CashondeliveryTax.php
@@ -80,8 +80,12 @@ class CashondeliveryTax extends AbstractTotal
             $total->setBaseTaxAmount($total->getBaseTaxAmount() + $baseTaxAmount);
             $total->setTaxAmount($total->getTaxAmount() + $taxAmount);
 
-            $total->setBaseGrandTotal($total->getBaseGrandTotal() + $baseTaxAmount);
-            $total->setGrandTotal($total->getGrandTotal() + $taxAmount);
+            if (!$this->cashOnDeliveryInterface->cashondeliveryFeeIncludesTax()) {
+                //If the configured fee does not already include the tax amount, then manually add it to the grand
+                //total
+                $total->setBaseGrandTotal($total->getBaseGrandTotal() + $baseTaxAmount);
+                $total->setGrandTotal($total->getGrandTotal() + $taxAmount);
+            }
         }
 
         /*

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -59,6 +59,11 @@
                     <label>Maximum Order Total</label>
                     <comment>Leave empty to disable limit</comment>
                 </field>
+                <field id="tax" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Fee prices in CSV file</label>
+                    <source_model>MSP\CashOnDelivery\Model\Config\Source\Fee\Tax</source_model>
+                    <comment>Indicates how to treat prices found in the CSV file.&lt;br/&gt;By default the setting in &lt;strong&gt;Sales -&gt; Tax -&gt; Calculation Settings -&gt; Shipping prices&lt;/strong&gt; is used.</comment>
+                </field>
                 <field id="export" translate="label" type="MSP\CashOnDelivery\Block\Adminhtml\Form\Field\Export" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Export</label>
                 </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -33,6 +33,7 @@
                 <sort_order>100</sort_order>
                 <group>offline</group>
                 <used_totals>subtotal,tax,shipping</used_totals>
+                <tax>0</tax>
             </msp_cashondelivery>
         </payment>
     </default>

--- a/i18n/it_IT.csv
+++ b/i18n/it_IT.csv
@@ -19,3 +19,6 @@ Import,Importa
 "Sort Order","Ordinamento"
 "Cash on delivery amount","Importo Del Contrassegno"
 "Cash on delivery tax","Iva sul Contrassegno"
+"Fee prices in CSV file","Prezzi del contrassegno nel CSV"
+"Use shipping price setting","Usa l'impostazione del prezzo di spedizione"
+"Indicates how to treat prices found in the CSV file.<br/>By default the setting in <strong>Sales -> Tax -> Calculation Settings -> Shipping prices</strong> is used.","Indica come trattare i prezzi nel file CSV.<br/>Di default si usa l'impostazione del campo <strong>Vendite -> Tassa -> Impostazioni di calcolo -> Prezzi di spedizione</strong>."

--- a/view/frontend/web/js/view/payment/method-renderer/cashondelivery.js
+++ b/view/frontend/web/js/view/payment/method-renderer/cashondelivery.js
@@ -49,6 +49,7 @@ define(
                 // otherwise it will fail. Perhaps there is better way to do this.
                 paymentData = JSON.parse(JSON.stringify(paymentData));
                 delete paymentData['title'];
+                delete paymentData['__disableTmpl'];    //Fix for Magento 2.3+
 
                 fullScreenLoader.startLoader();
                 


### PR DESCRIPTION
Removes the __disableTmpl field that causes issues with Magento 2.3+
Adds some configuration to allow more flexibility in managing the COD fee as far as the taxes are concerned.