### PR TITLE
Fixes an infinite loop when the quote is set to trigger recollect upon customer login

### DIFF
--- a/Model/Total/Quote/AbstractTotal.php
+++ b/Model/Total/Quote/AbstractTotal.php
@@ -20,20 +20,21 @@
 
 namespace MSP\CashOnDelivery\Model\Total\Quote;
 
-use Magento\Quote\Api\PaymentMethodManagementInterface;
+use Magento\Payment\Model\MethodList as PaymentMethodList;
 use Magento\Quote\Model\Quote\Address\Total\AbstractTotal as MageAbstractTotal;
 use Magento\Quote\Model\Quote;
+use MSP\CashOnDelivery\Model\Payment;
 
 abstract class AbstractTotal extends MageAbstractTotal
 {
     /**
-     * @var PaymentMethodManagementInterface
+     * @var PaymentMethodList
      */
-    private $paymentMethodManagement;
+    private $paymentMethodList;
 
-    public function __construct(PaymentMethodManagementInterface $paymentMethodManagement)
+    public function __construct(PaymentMethodList $paymentMethodList)
     {
-        $this->paymentMethodManagement = $paymentMethodManagement;
+        $this->paymentMethodList = $paymentMethodList;
     }
 
     /**
@@ -47,11 +48,13 @@ abstract class AbstractTotal extends MageAbstractTotal
         if (!$quote->getId()) {
             return false;
         }
-        $paymentMethodsList = $this->paymentMethodManagement->getList($quote->getId());
-        if ((count($paymentMethodsList) == 1) && (current($paymentMethodsList)->getCode() == 'msp_cashondelivery')) {
+
+        $paymentMethodsList = $this->paymentMethodList->getAvailableMethods($quote);
+        if ((count($paymentMethodsList) == 1) && (current($paymentMethodsList)->getCode() === Payment::CODE)) {
+            //Even if not currently selected, this is the only payment method available.
             return true;
         }
 
-        return ($quote->getPayment()->getMethod() == 'msp_cashondelivery');
+        return ($quote->getPayment()->getMethod() === Payment::CODE);
     }
 }

--- a/Model/Total/Quote/Cashondelivery.php
+++ b/Model/Total/Quote/Cashondelivery.php
@@ -21,7 +21,7 @@
 namespace MSP\CashOnDelivery\Model\Total\Quote;
 
 use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Quote\Api\PaymentMethodManagementInterface;
+use Magento\Payment\Model\MethodList as PaymentMethodList;
 use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 use Magento\Quote\Model\Quote;
@@ -34,11 +34,11 @@ class Cashondelivery extends AbstractTotal
     protected $priceCurrencyInterface;
 
     public function __construct(
-        PaymentMethodManagementInterface $paymentMethodManagement,
+        PaymentMethodList $paymentMethodList,
         PriceCurrencyInterface $priceCurrencyInterface,
         CashondeliveryInterface $cashOnDeliveryInterface
     ) {
-        parent::__construct($paymentMethodManagement);
+        parent::__construct($paymentMethodList);
 
         $this->cashOnDeliveryInterface = $cashOnDeliveryInterface;
         $this->priceCurrencyInterface = $priceCurrencyInterface;

--- a/Model/Total/Quote/CashondeliveryTax.php
+++ b/Model/Total/Quote/CashondeliveryTax.php
@@ -21,7 +21,7 @@
 namespace MSP\CashOnDelivery\Model\Total\Quote;
 
 use Magento\Framework\Pricing\PriceCurrencyInterface;
-use Magento\Quote\Api\PaymentMethodManagementInterface;
+use Magento\Payment\Model\MethodList as PaymentMethodList;
 use Magento\Quote\Model\Quote\Address\Total;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
 use Magento\Quote\Model\Quote;
@@ -34,11 +34,11 @@ class CashondeliveryTax extends AbstractTotal
     protected $priceCurrencyInterface;
 
     public function __construct(
-        PaymentMethodManagementInterface $paymentMethodManagement,
+        PaymentMethodList $paymentMethodList,
         PriceCurrencyInterface $priceCurrencyInterface,
         CashondeliveryInterface $cashOnDeliveryInterface
     ) {
-        parent::__construct($paymentMethodManagement);
+        parent::__construct($paymentMethodList);
         $this->cashOnDeliveryInterface = $cashOnDeliveryInterface;
         $this->priceCurrencyInterface = $priceCurrencyInterface;
     }


### PR DESCRIPTION
If a customer logs in when his saved quote has the "trigger_recollect" flag set to 1, an infinite loop occurs. This is because, while trying to collect the quote totals, the call to `paymentMethodManagement->getList()` tries to load the quote again, which in turn triggers another collection, which tries to load the quote...

With this PR I bypass the `paymentMethodManagement` object to use the `PaymentMethodList` instead, which takes the quote object directly and does not execute a DB load. This avoids trying to reload the quote and thus fixes the issue.